### PR TITLE
Ensure that Kibana uses the same port Nginx binds to

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -14,7 +14,7 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
 
-  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 8081, host: 8081
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,3 +1,3 @@
-azavea.nginx,0.1.1
+azavea.nginx,0.2.0
 azavea.logstash,0.1.0
 azavea.unzip,0.1.0

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -6,7 +6,7 @@
 
   roles:
     - { role: "azavea.logstash" }
-    - { role: "azavea.kibana" }
+    - { role: "azavea.kibana", kibana_port: 8081 }
 
   tasks:
     - name: Add Logstash user to service group

--- a/templates/kibana.conf.j2
+++ b/templates/kibana.conf.j2
@@ -1,5 +1,5 @@
 server {
-  listen *:80;
+  listen *:{{ kibana_port }};
 
   access_log /var/log/nginx/kibana.access.log;
 


### PR DESCRIPTION
Nginx reverse proxies requests to ElasticSearch and serves the static Kibana website. In order for Kibana to talk to ElasticSearch, it needs to direct its internal requests at Nginx, so that they can be proxied to Kibana.

This changeset also repairs the Kibana example in the `examples` directory.
