### PR TITLE
Update default kibana version to kibana 4-beta3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An Ansible role for installing [Kibana](http://www.elasticsearch.org/overview/ki
 
 ## Role Variables
 
-- `kibana_version` - Kibana version to install (default: `4.0.0-BETA2`)
+- `kibana_version` - Kibana version to install (default: `4.0.0-beta3`)
 - `kibana_dir` - Directory to extract the Kibana archive (default: `/opt`)
 - `kibana_host` - Kibana address to bind to (default: `0.0.0.0`)
 - `kibana_port` - Kibana port (default: `5601`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-kibana_version: "4.0.0-BETA2"
+kibana_version: "4.0.0-beta3"
 kibana_dir: "/opt"
 kibana_host: "0.0.0.0"
 kibana_port: "5601"

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -7,12 +7,16 @@ host: "{{ kibana_host }}"
 # The Elasticsearch instance to use for all your queries
 elasticsearch: "{{ kibana_elasticsearch }}"
 
+# preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
+# then the host you use to connect to *this* Kibana instance will be sent.
+elasticsearch_preserve_host: true
+
 # Kibana uses an index in Elasticsearch to store saved searches, visualizations
 # and dashboards. It will create an new index if it doesn't already exist.
-kibanaIndex: "{{ kibana_index }}"
+kibana_index: "{{ kibana_index }}"
 
 # The default application to load.
-defaultAppId: "discover"
+default_app_id: "discover"
 
 # Time in seconds to wait for responses from the back end or elasticsearch.
 # Note this should always be higher than "shard_timeout".


### PR DESCRIPTION
There shouldn't be any problems with swapping these out. Some [new features](http://www.elasticsearch.org/blog/kibana-4-beta-3-now-more-filtery/) are in the latest beta, but no breaking changes.
