### PR TITLE
Add support for Kibana 4 general release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ An Ansible role for installing [Kibana](http://www.elasticsearch.org/overview/ki
 
 ## Role Variables
 
-- `kibana_version` - Kibana version to install (default: `4.0.0-beta3`)
+- `kibana_version` - Kibana version to install (default: `4.0.0`)
+- `kibana_os` - Kibana operating system build (default: `linux`)
+- `kibana_arch` - Kibana architecture build (default: `x64`)
 - `kibana_dir` - Directory to extract the Kibana archive (default: `/opt`)
 - `kibana_host` - Kibana address to bind to (default: `0.0.0.0`)
 - `kibana_port` - Kibana port (default: `5601`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
-kibana_version: "4.0.0-beta3"
+kibana_version: "4.0.0"
+kibana_os: "linux"
+kibana_arch: "x64"
 kibana_dir: "/opt"
 kibana_host: "0.0.0.0"
 kibana_port: "5601"

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,4 +1,4 @@
-azavea.java,0.1.1
+azavea.java,0.2.1
 azavea.logstash,0.1.0
-azavea.unzip,0.1.0
+azavea.unzip,0.1.2
 azavea.elasticsearch,0.1.0

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,17 +1,14 @@
 ---
 - hosts: all
 
-  vars:
-    elasticsearch_cluster_name: "logstash"
-
   pre_tasks:
     - name: Update APT cache
       apt: update_cache=yes
 
   roles:
-    - { role: "azavea.elasticsearch" }
+    - { role: "azavea.elasticsearch", elasticsearch_version: "1.4.4" }
     - { role: "azavea.logstash" }
-    - { role: "azavea.kibana" }
+    - { role: "azavea.kibana", elasticsearch_cluster_name: "logstash" }
 
   tasks:
     - name: Add Logstash user to service group

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,18 +7,18 @@
         state=present
 
 - name: Download Kibana
-  get_url: url=https://download.elasticsearch.org/kibana/kibana/kibana-{{ kibana_version }}.zip
-           dest=/usr/local/src/kibana-{{ kibana_version }}.zip
+  get_url: url=https://download.elasticsearch.org/kibana/kibana/kibana-{{ kibana_version }}-{{ kibana_os }}-{{ kibana_arch }}.zip
+           dest=/usr/local/src/kibana-{{ kibana_version }}-{{ kibana_os }}-{{ kibana_arch }}.zip
 
 - name: Extract and install Kibana
-  unarchive: src=/usr/local/src/kibana-{{ kibana_version }}.zip
+  unarchive: src=/usr/local/src/kibana-{{ kibana_version }}-{{ kibana_os }}-{{ kibana_arch }}.zip
              dest={{ kibana_dir }}
              copy=no
-             creates={{ kibana_dir }}/kibana-{{ kibana_version }}
+             creates={{ kibana_dir }}/kibana-{{ kibana_version }}-{{ kibana_os }}-{{ kibana_arch }}
 
 - name: Configure Kibana
   template: src=kibana.yml.j2
-            dest={{ kibana_dir }}/kibana-{{ kibana_version }}/config/kibana.yml
+            dest={{ kibana_dir }}/kibana-{{ kibana_version }}-{{ kibana_os }}-{{ kibana_arch }}/config/kibana.yml
   notify:
     - Restart Kibana
 

--- a/templates/kibana.conf.j2
+++ b/templates/kibana.conf.j2
@@ -5,6 +5,6 @@ stop on shutdown
 
 respawn
 setuid kibana
-chdir {{ kibana_dir }}/kibana-{{ kibana_version }}
+chdir {{ kibana_dir }}/kibana-{{ kibana_version }}-{{ kibana_os }}-{{ kibana_arch }}
 
 exec ./bin/kibana >> {{ kibana_log }} 2>&1

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -1,40 +1,61 @@
 # Kibana is served by a back end server. This controls which port to use.
 port: {{ kibana_port }}
 
-# The host to bind the server to
+# The host to bind the server to.
 host: "{{ kibana_host }}"
 
-# The Elasticsearch instance to use for all your queries
-elasticsearch: "{{ kibana_elasticsearch }}"
+# The Elasticsearch instance to use for all your queries.
+elasticsearch_url: "{{ kibana_elasticsearch }}"
 
 # preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
 # then the host you use to connect to *this* Kibana instance will be sent.
 elasticsearch_preserve_host: true
 
 # Kibana uses an index in Elasticsearch to store saved searches, visualizations
-# and dashboards. It will create an new index if it doesn't already exist.
+# and dashboards. It will create a new index if it doesn't already exist.
 kibana_index: "{{ kibana_index }}"
+
+# If your Elasticsearch is protected with basic auth, this is the user credentials
+# used by the Kibana server to perform maintence on the kibana_index at statup. Your Kibana
+# users will still need to authenticate with Elasticsearch (which is proxied thorugh
+# the Kibana server)
+# kibana_elasticsearch_username: user
+# kibana_elasticsearch_password: pass
 
 # The default application to load.
 default_app_id: "discover"
 
-# Time in seconds to wait for responses from the back end or elasticsearch.
-# Note this should always be higher than "shard_timeout".
+# Time in milliseconds to wait for responses from the back end or elasticsearch.
 # This must be > 0
-request_timeout: 60
+request_timeout: 300000
 
-# Time in milliseconds for Elasticsearch to wait for responses from shards
-# Note this should always be lower than "request_timeout".
-# Set to 0 to disable (not recommended).
-shard_timeout: 30000
+# Time in milliseconds for Elasticsearch to wait for responses from shards.
+# Set to 0 to disable.
+shard_timeout: 0
 
-# Verify validity of SSL certificates
-verifySSL: true
+# Set to false to have a complete disregard for the validity of the SSL
+# certificate.
+verify_ssl: true
+
+# If you need to provide a CA certificate for your Elasticsarech instance, put
+# the path of the pem file here.
+# ca: /path/to/your/CA.pem
+
+# SSL for outgoing requests from the Kibana Server (PEM formatted)
+# ssl_key_file: /path/to/your/server.key
+# ssl_cert_file: /path/to/your/server.crt
+
+# Set the path to where you would like the process id file to be created.
+# pid_file: /var/run/kibana.pid
 
 # Plugins that are included in the build, and no longer found in the plugins/ folder
-bundledPluginIds:
+bundled_plugin_ids:
  - plugins/dashboard/index
  - plugins/discover/index
+ - plugins/doc/index
+ - plugins/kibana/index
+ - plugins/markdown_vis/index
+ - plugins/metric_vis/index
  - plugins/settings/index
  - plugins/table_vis/index
  - plugins/vis_types/index


### PR DESCRIPTION
This changeset bumps the default version of Kibana to version 4. One significant difference in version 4 is that the minimum version of ElasticSearch required is 1.4.4.

See also: https://github.com/azavea/ansible-elasticsearch/pull/1