### PR TITLE
Bump default version of Kibana to 4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An Ansible role for installing [Kibana](http://www.elasticsearch.org/overview/ki
 
 ## Role Variables
 
-- `kibana_version` - Kibana version to install (default: `4.0.0`)
+- `kibana_version` - Kibana version to install (default: `4.0.1`)
 - `kibana_os` - Kibana operating system build (default: `linux`)
 - `kibana_arch` - Kibana architecture build (default: `x64`)
 - `kibana_dir` - Directory to extract the Kibana archive (default: `/opt`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-kibana_version: "4.0.0"
+kibana_version: "4.0.1"
 kibana_os: "linux"
 kibana_arch: "x64"
 kibana_dir: "/opt"

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,4 +1,4 @@
 azavea.java,0.2.1
 azavea.logstash,0.1.0
 azavea.unzip,0.1.2
-azavea.elasticsearch,0.1.0
+azavea.elasticsearch,0.2.0


### PR DESCRIPTION
This changeset bumps the default version of Kibana to 4.0.1.
